### PR TITLE
Updated relengapi to mozilla-releng URL

### DIFF
--- a/misc.py
+++ b/misc.py
@@ -2448,7 +2448,7 @@ def generateSpiderMonkeyObjects(project, config, SLAVES):
             extra_args += ['--platform', platform]  # distinguish win64
             extra_args += [variant]
             extra_args += ['--ttserver',
-                           'https://api.pub.build.mozilla.org/tooltool/']
+                           'https://tooltool.mozilla-releng.net/']
 
             f = ScriptFactory(
                 config['scripts_repo'],


### PR DESCRIPTION
RelEngAPI is being migrated to Mozilla-RelEng.net

Dashboard: https://mozilla-releng.net/
API URL: https://tooltool.mozilla-releng.net/